### PR TITLE
Remove excess spaces in bindings

### DIFF
--- a/lib/app_component.html
+++ b/lib/app_component.html
@@ -8,7 +8,7 @@
     <material-list-item *ngFor="let item of names"
                         (trigger)="toggleSavedState(item)"
                         [class.added]="savedNames.contains(item)">
-      <span class="first">{{ item.first }}</span>{{ item.second }}.com
+      <span class="first">{{item.first}}</span>{{item.second}}.com
     </material-list-item>
 
   </div>
@@ -16,7 +16,7 @@
     <div label>Saved names</div>
     <material-list-item *ngFor="let item of savedNames"
                         (trigger)="removeFromSaved(item)">
-      <span class="first">{{ item.first }}</span>{{ item.second }}.com
+      <span class="first">{{item.first}}</span>{{item.second}}.com
     </material-list-item>
 
   </div>


### PR DESCRIPTION
To match style in Angular doc examples.